### PR TITLE
Write non-json portion of debug output to stderr

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -28,7 +28,7 @@ cli
       // convert tsconfig.json to swcrc
       const swcrc = convert(tsconfig, process.cwd(), oSwcOptions)
       if (debug) {
-        console.log('[debug] swcrc:')
+        console.err('[debug] swcrc:')
         console.log(JSON.stringify(swcrc, null, 2))
       }
       fs.writeFileSync(SWCRC_PATH, JSON.stringify(swcrc, null, 2))
@@ -37,7 +37,7 @@ cli
       const swcBin = require.resolve('.bin/swc')
       const swcArgs = [file, ...args['--'], '--config-file', SWCRC_PATH]
       if (debug) {
-        console.log(`> swc ${swcArgs.join(' ')}`)
+        console.err(`> swc ${swcArgs.join(' ')}`)
       }
       spawnSync(swcBin, swcArgs, {
         stdio: 'inherit',


### PR DESCRIPTION
This allows a user to use standard unix stdout redirect like

`./node_modules/.bin/tswc > .swcrc` without having to manually edit the result, making it more amenable for use in a toolchain.

Note, I didn't test this change at all.