### PR TITLE
feat: support jsonc comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@swc/cli": "^0.1.62",
         "cac": "^6.7.14",
+        "jsonc-parser": "^3.3.1",
         "tsconfig-to-swcconfig": "^2.2.0"
       },
       "bin": {
@@ -1956,9 +1957,9 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
     },
     "node_modules/keyv": {
       "version": "4.5.2",
@@ -4804,9 +4805,9 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
     },
     "keyv": {
       "version": "4.5.2",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,5 @@
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
-  },
-  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@swc/cli": "^0.1.62",
     "cac": "^6.7.14",
+    "jsonc-parser": "^3.3.1",
     "tsconfig-to-swcconfig": "^2.2.0"
   },
   "devDependencies": {
@@ -49,5 +50,6 @@
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import fs from 'fs'
 import { cac } from 'cac'
 import { convert } from 'tsconfig-to-swcconfig'
 import { spawnSync } from 'child_process'
+import { parse } from 'jsonc-parser'
 
 const cli = cac('tswc')
 
@@ -18,7 +19,7 @@ cli
     // read .swcrc
     const oSwcrcPath = path.resolve(process.cwd(), configFile)
     let oSwcOptions = fs.existsSync(oSwcrcPath)
-      ? JSON.parse(fs.readFileSync(oSwcrcPath, 'utf8'))
+      ? parse(fs.readFileSync(oSwcrcPath, 'utf8'))
       : {}
 
     const SWCRC_FILENAME =

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -10,49 +10,55 @@ const cliBin = path.join(__dirname, '..', 'src', 'cli.ts')
 
 describe('test suite', () => {
   it('generally work', ({ expect }) => {
-    const { stdout } = spawnSync(node, [cliBin], {
+    const proc = spawnSync(node, [cliBin], {
       stdio: 'pipe',
     })
-    expect(stdout.toString()).toBeTypeOf('string')
+    expect(proc.stdout.toString()).toBeTypeOf('string')
+    expect(proc.status).toBe(0)
   })
 
   it('compile some code', ({ expect }) => {
-    const { stdout } = spawnSync(
+    // const { stdout } = spawnSync(
+    const proc = spawnSync(
       node,
       [
         cliBin,
         path.join(__dirname, 'fixtures', 'src', 'index.ts'),
         '--config-file',
-        path.join(__dirname, 'test', 'fixtures', 'src', '.swcrc'),
+        path.join(__dirname, 'fixtures', 'src', '.swcrc'),
       ],
       { stdio: 'pipe' },
     )
-    expect(stdout.toString()).toMatch('') // success
+    expect(proc.status).toBe(0)
+    expect(proc.stderr.toString()).toMatch('')
+    expect(proc.stdout.toString()).toMatch('') // success
   })
 
   it('debug works', ({ expect }) => {
     const codePath = path.join(__dirname, 'fixtures', 'src', 'index.ts')
-    const { stdout } = spawnSync(
+    const proc = spawnSync(
       node,
       [cliBin, codePath, '--debug', '--tsconfig', 'tsconfig.json'],
       {
         stdio: 'pipe',
       },
     )
-    expect(stdout.toString()).toMatch(/\[debug\] swcrc:/)
+    expect(proc.status).toBe(0)
+    expect(proc.stdout.toString()).toMatch(/\[debug\] swcrc:/)
   })
 
   it('error throws', ({ expect }) => {
     const codePath = path.join(__dirname, 'fixtures', 'src', 'index.ts')
     try {
-      const { stderr } = spawnSync(
+      const proc = spawnSync(
         node,
         [cliBin, codePath, '--', '--random-args-for-error'],
         {
           stdio: 'pipe',
         },
       )
-      expect(stderr.toString()).toMatch(/error: unknown option/)
+      expect(proc.status).toBe(1)
+      expect(proc.stderr.toString()).toMatch(/error: unknown option/)
     } catch {}
   })
 })

--- a/test/fixtures/src/.swcrc
+++ b/test/fixtures/src/.swcrc
@@ -1,3 +1,4 @@
 {
+  // This is a general comment like .swcrc supports
   "minify": true
 }


### PR DESCRIPTION
# Summary

This PR does 2 things:

1. It updates the tests to actually use the config file in the test fixture (fixing a false-positive case)
2. It adds jsonc-parser (the same package as get-tsconfig in the base library) to support comments in .swcrc (which swc supports already)