### PR TITLE
Fix remove redundant config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,47 @@ You can change your build script in "package.json" as:
 
 Now you can run `npm run build` to build.
 
+### About .swcrc
+
+tswc will always merge your swc configuration file on top of any of the options that were inferred from your tsconfig.
+By default, swc and tswc will look for a .swcrc file and tolerate if there is none found.  However, tswc will respect
+any `--config-file` option that you provide to swc and will even make sure to throw an error if the file is missing.
+
+```shell
+# Example of using a .development.swcrc file to override the base config from tsconfig
+tswc -- --config-file .development.swcrc
+```
+
+As a naive example, if you had a tsconfig.json file that used commonjs compilation, but also wanted to compile an esm version,
+you could set up a .esm.swcrc so that:
+
+```json
+// tsconfig.json
+{
+  "module": "commonjs",
+  "moduleResolution": "node",
+  // Other options
+}
+
+// .esm.swcrc
+{
+  "module": {
+    // This overrides the module "commonjs" of tsconfig to es6
+    "type": "es6"
+  }
+}
+```
+
+The corresponding commands for this project might be something like:
+
+```shell
+# Creates esm syntax compiled files
+tswc -- src -d dist/esm --config-file .esm.swcrc
+
+# Creates commonjs syntax compiled files
+tswc -- src -d dist/esm
+```
+
 ## Notice
 
 Only a subgroup of fields of tsconfig is supported currently. This is done with [tsconfig-to-swcconfig](https://github.com/Songkeys/tsconfig-to-swcconfig). This means that some tsc features may be missing when compiling with this.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@swc/cli": "^0.1.62",
         "cac": "^6.7.14",
+        "jsonc-parser": "^3.3.1",
         "tsconfig-to-swcconfig": "^2.2.0"
       },
       "bin": {
@@ -1956,9 +1957,9 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "node_modules/jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
     },
     "node_modules/keyv": {
       "version": "4.5.2",
@@ -4804,9 +4805,9 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="
     },
     "jsonc-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-      "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="
     },
     "keyv": {
       "version": "4.5.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@swc/cli": "^0.1.62",
     "cac": "^6.7.14",
+    "jsonc-parser": "^3.3.1",
     "tsconfig-to-swcconfig": "^2.2.0"
   },
   "devDependencies": {
@@ -49,5 +50,6 @@
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import fs from 'fs'
 import { cac } from 'cac'
 import { convert } from 'tsconfig-to-swcconfig'
 import { spawnSync } from 'child_process'
+import { parse } from 'jsonc-parser'
 
 const cli = cac('tswc')
 
@@ -18,7 +19,7 @@ cli
     // read .swcrc
     const oSwcrcPath = path.resolve(process.cwd(), configFile)
     let oSwcOptions = fs.existsSync(oSwcrcPath)
-      ? JSON.parse(fs.readFileSync(oSwcrcPath, 'utf8'))
+      ? parse(fs.readFileSync(oSwcrcPath, 'utf8'))
       : {}
 
     const SWCRC_FILENAME =

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,7 +66,8 @@ cli
 
       // compile
       const swcBin = require.resolve('.bin/swc')
-      const swcArgs = [file, ..._swcArgs, '--config-file', SWCRC_PATH]
+      const cleanedSwcArgs = removeDuplicateConfigFileFromArgs(_swcArgsFull, configFile)
+      const swcArgs = [file, ...cleanedSwcArgs, '--config-file', SWCRC_PATH]
       if (debug) {
         console.log(`> swc ${swcArgs.join(' ')}`)
       }
@@ -82,6 +83,26 @@ cli
       fs.unlinkSync(SWCRC_PATH)
     }
   })
+
+  /**
+   * Removes the --config-file option and its value from an array of raw swc args
+   * @param swcArgs 
+   * @param configFileArg - the --config-file value argument that you parsed already
+   * @returns 
+   */
+function removeDuplicateConfigFileFromArgs(swcArgs: string[], configFileArg?: string) {
+  let lastArgWasConfigFile = false
+  return configFileArg ? swcArgs.reduce((cleanArgs: string[], arg: string) => {
+    if (arg === '--config-file') {
+      lastArgWasConfigFile = true
+    } else if (lastArgWasConfigFile && arg === configFileArg) {
+      // We don't push anything here because the second arg is also skipped
+    } else {
+      cleanArgs.push(arg)
+    }
+    return cleanArgs
+  }, [] as string[]) : swcArgs
+}
 
 cli.help()
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -9,7 +9,7 @@ const cliBin = path.join(__dirname, '..', 'src', 'cli.ts')
 // const cliBin = path.join(__dirname, '..', 'dist', 'cli.js')
 
 describe('test suite', () => {
-  it('generally work', ({ expect }) => {
+  it('generally works', ({ expect }) => {
     const proc = spawnSync(node, [cliBin], {
       stdio: 'pipe',
     })
@@ -17,12 +17,13 @@ describe('test suite', () => {
     expect(proc.status).toBe(0)
   })
 
-  it('compile some code', ({ expect }) => {
-    // const { stdout } = spawnSync(
+  it('compiles some code', ({ expect }) => {
     const proc = spawnSync(
       node,
       [
         cliBin,
+        '--',
+        // swc args
         path.join(__dirname, 'fixtures', 'src', 'index.ts'),
         '--config-file',
         path.join(__dirname, 'fixtures', 'src', '.swcrc'),
@@ -59,6 +60,27 @@ describe('test suite', () => {
       )
       expect(proc.status).toBe(1)
       expect(proc.stderr.toString()).toMatch(/error: unknown option/)
+    } catch {}
+  })
+  it('throws if the config does not exist', ({ expect }) => {
+    const codePath = path.join(__dirname, 'fixtures', 'src', 'index.ts')
+    try {
+      const proc = spawnSync(
+        node,
+        [
+          cliBin,
+          // swc arguments
+          '--',
+          path.join(__dirname, 'fixtures', 'src', 'index.ts'),
+          '--config-file',
+          path.join(__dirname, 'fixtures', 'src', 'nope.swcrc'),
+        ],
+        { stdio: 'pipe' },
+      )
+      expect(proc.status).toBe(1)
+      expect(proc.stderr.toString()).toMatch(
+        /Invalid option: --config-file. Could not find file:/,
+      )
     } catch {}
   })
 })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -10,49 +10,55 @@ const cliBin = path.join(__dirname, '..', 'src', 'cli.ts')
 
 describe('test suite', () => {
   it('generally work', ({ expect }) => {
-    const { stdout } = spawnSync(node, [cliBin], {
+    const proc = spawnSync(node, [cliBin], {
       stdio: 'pipe',
     })
-    expect(stdout.toString()).toBeTypeOf('string')
+    expect(proc.stdout.toString()).toBeTypeOf('string')
+    expect(proc.status).toBe(0)
   })
 
   it('compile some code', ({ expect }) => {
-    const { stdout } = spawnSync(
+    // const { stdout } = spawnSync(
+    const proc = spawnSync(
       node,
       [
         cliBin,
         path.join(__dirname, 'fixtures', 'src', 'index.ts'),
         '--config-file',
-        path.join(__dirname, 'test', 'fixtures', 'src', '.swcrc'),
+        path.join(__dirname, 'fixtures', 'src', '.swcrc'),
       ],
       { stdio: 'pipe' },
     )
-    expect(stdout.toString()).toMatch('') // success
+    expect(proc.status).toBe(0)
+    expect(proc.stderr.toString()).toMatch('')
+    expect(proc.stdout.toString()).toMatch('') // success
   })
 
   it('debug works', ({ expect }) => {
     const codePath = path.join(__dirname, 'fixtures', 'src', 'index.ts')
-    const { stdout } = spawnSync(
+    const proc = spawnSync(
       node,
       [cliBin, codePath, '--debug', '--tsconfig', 'tsconfig.json'],
       {
         stdio: 'pipe',
       },
     )
-    expect(stdout.toString()).toMatch(/\[debug\] swcrc:/)
+    expect(proc.status).toBe(0)
+    expect(proc.stdout.toString()).toMatch(/\[debug\] swcrc:/)
   })
 
   it('error throws', ({ expect }) => {
     const codePath = path.join(__dirname, 'fixtures', 'src', 'index.ts')
     try {
-      const { stderr } = spawnSync(
+      const proc = spawnSync(
         node,
         [cliBin, codePath, '--', '--random-args-for-error'],
         {
           stdio: 'pipe',
         },
       )
-      expect(stderr.toString()).toMatch(/error: unknown option/)
+      expect(proc.status).toBe(1)
+      expect(proc.stderr.toString()).toMatch(/error: unknown option/)
     } catch {}
   })
 })

--- a/test/fixtures/src/.swcrc
+++ b/test/fixtures/src/.swcrc
@@ -1,3 +1,4 @@
 {
+  // This is a general comment like .swcrc supports
   "minify": true
 }


### PR DESCRIPTION
# Summary

This is not an impactor right now, but could be in the future.  When debugging the library locally, I realized that we don't remove the --config-file from the args and end up with a call like:

```
swc --config-file .esm.swcrc -d dist --config-file tswcrc
```

To prevent some change in ordering in the CLI library from creating erroneous results, I have added a clean method to the args that we pass in if a configFile was detected.