### PR TITLE
feat: strict config file source

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,47 @@ You can change your build script in "package.json" as:
 
 Now you can run `npm run build` to build.
 
+### About .swcrc
+
+tswc will always merge your swc configuration file on top of any of the options that were inferred from your tsconfig.
+By default, swc and tswc will look for a .swcrc file and tolerate if there is none found.  However, tswc will respect
+any `--config-file` option that you provide to swc and will even make sure to throw an error if the file is missing.
+
+```shell
+# Example of using a .development.swcrc file to override the base config from tsconfig
+tswc -- --config-file .development.swcrc
+```
+
+As a naive example, if you had a tsconfig.json file that used commonjs compilation, but also wanted to compile an esm version,
+you could set up a .esm.swcrc so that:
+
+```json
+// tsconfig.json
+{
+  "module": "commonjs",
+  "moduleResolution": "node",
+  // Other options
+}
+
+// .esm.swcrc
+{
+  "module": {
+    // This overrides the module "commonjs" of tsconfig to es6
+    "type": "es6"
+  }
+}
+```
+
+The corresponding commands for this project might be something like:
+
+```shell
+# Creates esm syntax compiled files
+tswc -- src -d dist/esm --config-file .esm.swcrc
+
+# Creates commonjs syntax compiled files
+tswc -- src -d dist/esm
+```
+
 ## Notice
 
 Only a subgroup of fields of tsconfig is supported currently. This is done with [tsconfig-to-swcconfig](https://github.com/Songkeys/tsconfig-to-swcconfig). This means that some tsc features may be missing when compiling with this.

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -9,7 +9,7 @@ const cliBin = path.join(__dirname, '..', 'src', 'cli.ts')
 // const cliBin = path.join(__dirname, '..', 'dist', 'cli.js')
 
 describe('test suite', () => {
-  it('generally work', ({ expect }) => {
+  it('generally works', ({ expect }) => {
     const proc = spawnSync(node, [cliBin], {
       stdio: 'pipe',
     })
@@ -17,12 +17,13 @@ describe('test suite', () => {
     expect(proc.status).toBe(0)
   })
 
-  it('compile some code', ({ expect }) => {
-    // const { stdout } = spawnSync(
+  it('compiles some code', ({ expect }) => {
     const proc = spawnSync(
       node,
       [
         cliBin,
+        '--',
+        // swc args
         path.join(__dirname, 'fixtures', 'src', 'index.ts'),
         '--config-file',
         path.join(__dirname, 'fixtures', 'src', '.swcrc'),
@@ -59,6 +60,27 @@ describe('test suite', () => {
       )
       expect(proc.status).toBe(1)
       expect(proc.stderr.toString()).toMatch(/error: unknown option/)
+    } catch {}
+  })
+  it('throws if the config does not exist', ({ expect }) => {
+    const codePath = path.join(__dirname, 'fixtures', 'src', 'index.ts')
+    try {
+      const proc = spawnSync(
+        node,
+        [
+          cliBin,
+          // swc arguments
+          '--',
+          path.join(__dirname, 'fixtures', 'src', 'index.ts'),
+          '--config-file',
+          path.join(__dirname, 'fixtures', 'src', 'nope.swcrc'),
+        ],
+        { stdio: 'pipe' },
+      )
+      expect(proc.status).toBe(1)
+      expect(proc.stderr.toString()).toMatch(
+        /Invalid option: --config-file. Could not find file:/,
+      )
     } catch {}
   })
 })


### PR DESCRIPTION
Apologies @songkeys, I didn't realize Github wouldn't allow me to switch targets to your repo after the initial PR.  I've opened this after having answered your questions.

## Summary

This PR adds some more QOL improvements to the CLI:

 1. if config file is provided, it checks that the file exists and throws an error if not, since users should not be using non-existent files and getting wrongly merged content
  2. Switches to using the expected swc --config-file option instead of expected a separate one. This involves us stubbing a nominal expected CLI and parsing the args provided after --
  3. Removes allowing other values in the cli and uses '--' as an explicit option so that we can throw is people use config-file in the wrong place, etc.
  4. Adds a demonstration of how to use `--config-file` to the readme

