### PR TITLE
test fix for windows

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,7 @@ cli
     const { tsconfig, debug } = options
     const _swcArgs = options['--']
     // parse shared swc args here
-    const swcParsedArgs = expectedSwcCli.parse(_swcArgs) as {
+    const swcParsedArgs = expectedSwcCli.parse(["swc", ..._swcArgs]) as {
       options: {
         configFile?: string
       }
@@ -40,9 +40,11 @@ cli
     if (configFile) {
       oSwcrcPath = path.resolve(process.cwd(), configFile)
       if (!fs.existsSync(oSwcrcPath)) {
-        throw new Error(
+        console.error(
           `Invalid option: --config-file. Could not find file: ${oSwcrcPath}`,
         )
+        process.exitCode = 1;
+        return;
       }
     } else {
       oSwcrcPath = path.resolve(process.cwd(), '.swcrc')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -73,16 +73,21 @@ cli
       if (debug) {
         console.log(`> swc ${swcArgs.join(' ')}`)
       }
-      spawnSync(swcBin, swcArgs, {
+      const results = spawnSync(swcBin, swcArgs, {
         stdio: 'inherit',
         cwd: process.cwd(),
         env: process.env,
         // Windows does not do spawn well without shell explicitly set
         shell: process.platform === "win32" ? true : undefined,
       })
+      // Propagate the status code to this program
+      if (results.status) {
+        process.exitCode = results.status
+      }
     } catch (e) {
       /* istanbul ignore next */
       console.error(e)
+      process.exitCode = 1;
     } finally {
       fs.unlinkSync(SWCRC_PATH)
     }

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -12,7 +12,7 @@ const shell = process.platform === 'win32' ? true : undefined;
 
 describe('test suite', () => {
   it('generally works', ({ expect }) => {
-    const proc = spawnSync(node, [cliBin], {
+    const proc = spawnSync(node, [cliBin, '--help'], {
       stdio: 'pipe',
       shell,
     })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -50,7 +50,6 @@ describe('test suite', () => {
     expect(proc.status).toBe(0)
     expect(proc.stdout.toString()).toMatch(/\[debug\] swcrc:/)
   })
-
   it('error throws', ({ expect }) => {
     const codePath = path.join(__dirname, 'fixtures', 'src', 'index.ts')
     const proc = spawnSync(
@@ -62,6 +61,18 @@ describe('test suite', () => {
     )
     expect(proc.status).toBe(1)
     expect(proc.stderr.toString()).toMatch(/error: unknown option/)
+  })
+  it('propagates the error code of swc', ({ expect }) => {
+    const codePath = path.join(__dirname, 'fixtures', 'src', 'bad.ts')
+    const proc = spawnSync(
+      node,
+      [cliBin, codePath, '--tsconfig', 'tsconfig.json'],
+      {
+        stdio: 'pipe', shell,
+      },
+    )
+    expect(proc.status).toBe(1)
+    expect(proc.stderr.toString()).toMatch(/Syntax Error/)
   })
   it('throws if the config does not exist', ({ expect }) => {
     const codePath = path.join(__dirname, 'fixtures', 'src', 'index.ts')

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -53,37 +53,33 @@ describe('test suite', () => {
 
   it('error throws', ({ expect }) => {
     const codePath = path.join(__dirname, 'fixtures', 'src', 'index.ts')
-    try {
-      const proc = spawnSync(
-        node,
-        [cliBin, codePath, '--', '--random-args-for-error'],
-        {
-          stdio: 'pipe', shell,
-        },
-      )
-      expect(proc.status).toBe(1)
-      expect(proc.stderr.toString()).toMatch(/error: unknown option/)
-    } catch {}
+    const proc = spawnSync(
+      node,
+      [cliBin, codePath, '--', '--random-args-for-error'],
+      {
+        stdio: 'pipe', shell,
+      },
+    )
+    expect(proc.status).toBe(1)
+    expect(proc.stderr.toString()).toMatch(/error: unknown option/)
   })
   it('throws if the config does not exist', ({ expect }) => {
     const codePath = path.join(__dirname, 'fixtures', 'src', 'index.ts')
-    try {
-      const proc = spawnSync(
-        node,
-        [
-          cliBin,
-          // swc arguments
-          '--',
-          path.join(__dirname, 'fixtures', 'src', 'index.ts'),
-          '--config-file',
-          path.join(__dirname, 'fixtures', 'src', 'nope.swcrc'),
-        ],
-        { stdio: 'pipe', shell },
-      )
-      expect(proc.status).toBe(1)
-      expect(proc.stderr.toString()).toMatch(
-        /Invalid option: --config-file. Could not find file:/,
-      )
-    } catch {}
+    const proc = spawnSync(
+      node,
+      [
+        cliBin,
+        // swc arguments
+        '--',
+        codePath,
+        '--config-file',
+        path.join(__dirname, 'fixtures', 'src', 'nope.swcrc'),
+      ],
+      { stdio: 'pipe', shell },
+    )
+    expect(proc.status).toBe(1)
+    expect(proc.stderr.toString()).toMatch(
+      /Invalid option: --config-file. Could not find file:/,
+    )
   })
 })

--- a/test/fixtures/src/bad.ts
+++ b/test/fixtures/src/bad.ts
@@ -1,0 +1,2 @@
+// This is supposed to have a syntax error to test swc compilation failure
+const const badVariableToBuild = 'something';


### PR DESCRIPTION
# Summary

This should fix the windows test that was breaking.  We explicitly set help since windows was interpreting it as a broken stdin call.